### PR TITLE
[E2E] GnOuGo intention-first agent review fixture

### DIFF
--- a/e2e-fixtures/IntentPrReviewFixture-20260805013208-8dabd668.cs
+++ b/e2e-fixtures/IntentPrReviewFixture-20260805013208-8dabd668.cs
@@ -1,0 +1,13 @@
+namespace GnOuGo.E2E;
+
+// Disposable correctness fixture used only by the live intention-first agent test.
+public static class IntentReviewFixture
+{
+    public static int Divide(int numerator, int denominator)
+    {
+        if (denominator == 0)
+            throw new DivideByZeroException();
+
+        return numerator / (denominator - denominator);
+    }
+}


### PR DESCRIPTION
Disposable fixture for validating the generated intention-first review agent. It must never be merged.