### PR TITLE
fix: handle union types in OpenAI strict schemas

### DIFF
--- a/src/GnOuGo.AI.Core/ChatRequestBuilder.cs
+++ b/src/GnOuGo.AI.Core/ChatRequestBuilder.cs
@@ -452,9 +452,9 @@ public static class ChatRequestBuilder
     {
         if (schema is not JsonObject obj) return schema;
 
-        // If this node describes an object type, inject additionalProperties: false
-        var typeVal = obj["type"]?.GetValue<string>();
-        if (typeVal == "object")
+        // If this node describes an object type, inject additionalProperties: false.
+        // JSON Schema permits either a scalar type or a union expressed as an array.
+        if (IncludesSchemaType(obj["type"], "object"))
         {
             obj["additionalProperties"] = false;
         }
@@ -487,6 +487,30 @@ public static class ChatRequestBuilder
         }
 
         return obj;
+    }
+
+    private static bool IncludesSchemaType(JsonNode? typeNode, string expectedType)
+    {
+        if (typeNode is JsonValue scalar)
+        {
+            return scalar.TryGetValue<string>(out var type)
+                && string.Equals(type, expectedType, StringComparison.Ordinal);
+        }
+
+        if (typeNode is JsonArray union)
+        {
+            foreach (var member in union)
+            {
+                if (member is JsonValue value
+                    && value.TryGetValue<string>(out var type)
+                    && string.Equals(type, expectedType, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }
 

--- a/src/GnOuGo.Flow.Core/Runtime/Executors/WorkflowPlanExecutor.Pipeline.cs
+++ b/src/GnOuGo.Flow.Core/Runtime/Executors/WorkflowPlanExecutor.Pipeline.cs
@@ -2320,7 +2320,7 @@ public sealed partial class WorkflowPlanExecutor : IStepExecutor
                     "items": {
                       "type": "object",
                       "additionalProperties": false,
-                      "required": ["server", "kind", "method", "required", "purpose", "consumes", "produces"],
+                      "required": ["server", "kind", "method", "operation_ids", "catalog_ids", "request_bindings", "required", "purpose", "consumes", "produces"],
                       "properties": {
                         "server": { "type": "string" },
                         "kind": { "type": "string", "enum": ["tool", "prompt"] },

--- a/tests/GnOuGo.AI.Core.Tests/ChatRequestBuilderTests.cs
+++ b/tests/GnOuGo.AI.Core.Tests/ChatRequestBuilderTests.cs
@@ -183,5 +183,59 @@ public sealed class ChatRequestBuilderTests
         Assert.Null(anyOf[1]!["type"]);
         Assert.False(schema.AsObject().ContainsKey("additionalProperties"));
     }
+
+    [Fact]
+    public void OpenAiResponsesBackground_PreservesUnionTypesAndPatchesObjectUnionsWithoutMutation()
+    {
+        var schema = JsonNode.Parse("""
+        {
+          "type": ["object", "null"],
+          "properties": {
+            "entry": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": ["string", "number", "boolean", "null"]
+                }
+              },
+              "required": ["value"]
+            }
+          },
+          "required": ["entry"]
+        }
+        """)!;
+
+        var original = schema.ToJsonString();
+
+        var payload = ChatRequestBuilder.OpenAiResponsesBackground(
+            model: "gpt-4o-mini",
+            prompt: "Extract values",
+            temperature: null,
+            reasoning: null,
+            structuredOutputSchema: schema,
+            structuredOutputStrict: true,
+            maxOutputTokens: null);
+
+        using var doc = JsonDocument.Parse(payload);
+        var responseSchema = doc.RootElement
+            .GetProperty("text")
+            .GetProperty("format")
+            .GetProperty("schema");
+        var rootTypes = responseSchema.GetProperty("type").EnumerateArray().Select(type => type.GetString()!).ToArray();
+        var entry = responseSchema.GetProperty("properties").GetProperty("entry");
+        var valueTypes = entry
+            .GetProperty("properties")
+            .GetProperty("value")
+            .GetProperty("type")
+            .EnumerateArray()
+            .Select(type => type.GetString()!)
+            .ToArray();
+
+        Assert.Equal(["object", "null"], rootTypes);
+        Assert.Equal(["string", "number", "boolean", "null"], valueTypes);
+        Assert.False(responseSchema.GetProperty("additionalProperties").GetBoolean());
+        Assert.False(entry.GetProperty("additionalProperties").GetBoolean());
+        Assert.Equal(original, schema.ToJsonString());
+    }
 }
 

--- a/tests/GnOuGo.AI.Core.Tests/OpenAiLLMProviderTests.cs
+++ b/tests/GnOuGo.AI.Core.Tests/OpenAiLLMProviderTests.cs
@@ -72,9 +72,17 @@ public sealed class OpenAiLlmProviderTests
                 {
                   "type": "object",
                   "properties": {
-                    "name": { "type": "string" }
+                    "name": { "type": "string" },
+                    "value": { "type": ["string", "number", "boolean", "null"] },
+                    "metadata": {
+                      "type": ["object", "null"],
+                      "properties": {
+                        "source": { "type": "string" }
+                      },
+                      "required": ["source"]
+                    }
                   },
-                  "required": ["name"]
+                  "required": ["name", "value", "metadata"]
                 }
                 """)
             },
@@ -98,8 +106,18 @@ public sealed class OpenAiLlmProviderTests
         Assert.Equal("json_schema", format.GetProperty("type").GetString());
         Assert.Equal("output", format.GetProperty("name").GetString());
         Assert.True(format.GetProperty("strict").GetBoolean());
-        Assert.Equal("object", format.GetProperty("schema").GetProperty("type").GetString());
-        Assert.False(format.GetProperty("schema").GetProperty("additionalProperties").GetBoolean());
+        var responseSchema = format.GetProperty("schema");
+        Assert.Equal("object", responseSchema.GetProperty("type").GetString());
+        Assert.False(responseSchema.GetProperty("additionalProperties").GetBoolean());
+        Assert.Equal(
+            ["string", "number", "boolean", "null"],
+            responseSchema.GetProperty("properties").GetProperty("value").GetProperty("type")
+                .EnumerateArray().Select(type => type.GetString()!).ToArray());
+        var metadata = responseSchema.GetProperty("properties").GetProperty("metadata");
+        Assert.Equal(
+            ["object", "null"],
+            metadata.GetProperty("type").EnumerateArray().Select(type => type.GetString()!).ToArray());
+        Assert.False(metadata.GetProperty("additionalProperties").GetBoolean());
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Information
             && e.Message.Contains("UseBackgroundMode=True", StringComparison.Ordinal));
         Assert.Contains(logger.Entries, e => e.Level == LogLevel.Information

--- a/tests/GnOuGo.Flow.Tests/Runtime/WorkflowPlanExecutorTests.cs
+++ b/tests/GnOuGo.Flow.Tests/Runtime/WorkflowPlanExecutorTests.cs
@@ -3287,6 +3287,11 @@ workflows:
         Assert.Contains(requiredFields, field => field!.GetValue<string>() == "work_kind");
         Assert.Contains(requiredFields, field => field!.GetValue<string>() == "contract_role");
         Assert.Contains(requiredFields, field => field!.GetValue<string>() == "concrete_outcome");
+        var plannedToolItems = Assert.IsType<JsonObject>(subworkflowItems["properties"]!["planned_tools"]!["items"]);
+        var plannedToolRequiredFields = Assert.IsType<JsonArray>(plannedToolItems["required"]);
+        Assert.Contains(plannedToolRequiredFields, field => field!.GetValue<string>() == "operation_ids");
+        Assert.Contains(plannedToolRequiredFields, field => field!.GetValue<string>() == "catalog_ids");
+        Assert.Contains(plannedToolRequiredFields, field => field!.GetValue<string>() == "request_bindings");
 
         var pipeline = Assert.IsType<JsonObject>(planOutput["pipeline"]);
         var specs = Assert.IsType<JsonObject>(pipeline["specs"]);


### PR DESCRIPTION
## What changed

- handle JSON Schema `type` values expressed as either a scalar or an array when applying OpenAI strict-output object constraints
- preserve union members while adding `additionalProperties: false` to scalar and nullable object schemas
- require the always-materialized `operation_ids`, `catalog_ids`, and `request_bindings` fields in the workflow extraction schema
- add builder, provider HTTP, and Flow pipeline regressions

## Why

Diagnostic trace `0a2f301b49aee46c8a589c2ac04be9a5` failed in `ChatRequestBuilder.PatchAdditionalProperties` because it called `GetValue<string>()` on the valid union schema `["string", "number", "boolean", "null"]`. Once that crash was removed, live validation exposed an OpenAI strict-schema rejection because three planned-tool properties were present but absent from `required`.

## Impact

`/gnougo add` can transmit the affected strict structured-output schema without the `JsonValue` exception or the subsequent missing-`required` 400 response. There are no public API or persistence changes.

## Validation

- `GnOuGo.AI.Core.Tests`: 132 passed
- `GnOuGo.Flow.Tests`: 948 passed
- `GnOuGo.Agent.Server.Tests`: 255 passed
- GitHub Actions run [31876418137](https://github.com/GnouGo/GnouGo/actions/runs/31876418137): all pull-request checks passed; package publishing was intentionally skipped
- live configured generation reached capability inference with no `JsonValue` exception and OpenAI accepted the corrected strict schema
- exact original prompt was attempted three times; each advanced past structured output but stopped safely on downstream capability ambiguity, so no `code-review` agent was persisted and no review was posted to AxaFrance/SmartGuide#499
- full solution run also exposed three deterministic failures outside this diff (GitHub Copilot prompt bound, Git MCP Windows error classification, animation newline assertion); a transient KeyVault SQLite failure passed in isolation
